### PR TITLE
FIx: Move completions generation to post_install

### DIFF
--- a/Formula/talosctl.rb
+++ b/Formula/talosctl.rb
@@ -43,6 +43,9 @@ class Talosctl < Formula
     elsif OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       bin.install "talosctl-linux-arm64" => "talosctl"
     end
+  end
+
+  def post_install
     generate_completions_from_executable(bin/"talosctl", "completion")
   end
 


### PR DESCRIPTION
Because generate_completions_from_executable is called in install part, the binary is not yet installed at that point. This results in:
```
$ brew install talosctl 
==> Fetching siderolabs/tap/talosctl
==> Downloading https://github.com/siderolabs/talos/releases/download/v1.6.4/talosctl-darwin-arm64
Already downloaded: /Users/maslyankov/Library/Caches/Homebrew/downloads/485b9ad5cac364a22d306b8aec2e873157cfde360ccac1576ee4e4dfae896eb1--talosctl-darwin-arm64
==> Installing talosctl from siderolabs/tap
brew: exec failed: {"SHELL"=>"bash"}
Error: Failure while executing; `\{\"SHELL\"=\>\"bash\"\} /opt/homebrew/Cellar/talosctl/1.6.4/bin/talosctl completion bash` exited with 1. Here's the output:
```

Moving the generate_completions_from_executable to post_install seems to solve the issue.