### PR TITLE
chore: update omnictl to v0.52.0

### DIFF
--- a/Formula/omnictl.rb
+++ b/Formula/omnictl.rb
@@ -4,25 +4,25 @@
 class Omnictl < Formula
   desc "CLI for Omni - SaaS-simple deployment of Kubernetes - on your own hardware."
   homepage "https://omni.siderolabs.com/"
-  version "0.51.0"
+  version "0.52.0"
   license "BUSL-1.1"
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/siderolabs/omni/releases/download/v#{version}/omnictl-darwin-amd64",
       verified: "github.com/siderolabs/omni/"
-    sha256 "3c3654aeba871c013cb5aa9657c2066ffe38f59ad4140d0e1cb18a03f943d10a"
+    sha256 "3a6ff01b9b6843bb3607c3c34be7c91a11599a71c0b354b470e818f7ee6737a3"
   elsif OS.mac? && Hardware::CPU.arm?
     url "https://github.com/siderolabs/omni/releases/download/v#{version}/omnictl-darwin-arm64",
       verified: "github.com/siderolabs/omni/"
-    sha256 "a86b2cd9c7f54301404d2596dee1f1fa8897673c5e2d7d11cb4b556b9d8f8264"
+    sha256 "7d0a553c9f3024f61f506677775ac5026b848d6283dca878ee2083d5ff2b3e08"
   elsif OS.linux? && Hardware::CPU.intel?
     url "https://github.com/siderolabs/omni/releases/download/v#{version}/omnictl-linux-amd64",
       verified: "github.com/siderolabs/omni/"
-    sha256 "cda75899d31f1a32cb44d7010a3bbc8b9a2a0590028aa30457737a71d32f04e3"
+    sha256 "9293c01805b2148fe719b3c510672f8e98c63cca2a691848195a0e8404029d0f"
   elsif OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
     url "https://github.com/siderolabs/omni/releases/download/v#{version}/omnictl-linux-arm64",
       verified: "github.com/siderolabs/omni/"
-    sha256 "e8095d7156c8e82927f8c38a97cb7cba3e8aa478c85205135cee3fd25749a2d0"
+    sha256 "20dcb75581aa042385271914b850a7e198ee9ce509e5efaf4f890caab5131aba"
   else
     odie "Unexpected platform!"
   end


### PR DESCRIPTION
Bump `omnictl` version to the [latest v.52.0 release](https://github.com/siderolabs/omni/releases/tag/v0.52.0).