### PR TITLE
chore: update update.sh for macOS compatibility

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -14,24 +14,37 @@ tool="${1}"
 formula="./Formula/${tool}.rb"
 tmp_file="/tmp/${tool}.tmp"
 
-lines="$(grep -Po '(url "\K[^"]+)|(sha256 "\K[^"]+)' "${formula}")"
+lines="$(awk -F'"' '/url "|sha256 "/ {print $2}' "${formula}")"
 while IFS= read -r url && read -r hash; do
     new_url="${url/"#{version}"/"${new_ver}"}"
     echo "===> Downloading \"${new_url}\"..."
-    wget -q -O "${tmp_file}" "${new_url}"
+    if command -v wget >/dev/null 2>&1; then
+        wget -q -O "${tmp_file}" "${new_url}"
+    else
+        curl -sSL -o "${tmp_file}" "${new_url}"
+    fi
 
     echo "=====> Calculation SHA256 checksum..."
-    new_hash=($(sha256sum ${tmp_file}))
+    new_hash=$(shasum -a 256 "${tmp_file}" | awk '{print $1}')
     echo "=====> sha256: ${new_hash}"
 
     echo "=====> Updating hash in \"${formula}\"..."
-    sed -i "s/${hash}/${new_hash}/" ${formula}
+    if [[ "$(uname)" == "Darwin" ]]; then
+        sed -i '' "s/${hash}/${new_hash}/" "${formula}"
+    else
+        sed -i "s/${hash}/${new_hash}/" "${formula}"
+    fi
 
     rm ${tmp_file}
 done <<< "${lines}"
 
-current_ver="$(grep -Po 'version "\K(\d+\.\d+\.\d+)' "${formula}")"
+# extract current version string from the formula
+current_ver="$(awk -F'"' '/^  version/ {print $2}' "${formula}")"
 echo "===> Updating version in formula \"${formula}\": ${current_ver} -> ${new_ver}"
-sed -i "s/$(echo ${current_ver} | sed 's|\.|\\.|g')/${new_ver}/" ${formula}
+if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i '' "s/$(echo ${current_ver} | sed 's|\.|\\.|g')/${new_ver}/" "${formula}"
+else
+    sed -i "s/$(echo ${current_ver} | sed 's|\.|\\.|g')/${new_ver}/" "${formula}"
+fi
 
 echo "===> Done."


### PR DESCRIPTION
Makes `update.sh` work out of the box on macOS while maintaining Linux support.

(I had `grep: invalid option -- P` on macOS which ships with BSD `grep`.)

changes:
• swapped `grep -Po` (GNU-only) for `awk` (portable)
• fall back to `curl` if `wget` is absent (macOS doesn't ship with `wget`)
• use `shasum -a 256` on macOS (no `sha256sum` there...)
• add BSD-sed in-place flag (`sed -i '' …`) gated by `uname`

Tested on macOS 15.4 (arm64 M4) and Ubuntu 22.04 (in Docker). Would be beneficial if @UnknownBlunders could review by testing the updated script in his environment.