### PR TITLE
chore: update talosctl to v1.11.0

### DIFF
--- a/Formula/talosctl.rb
+++ b/Formula/talosctl.rb
@@ -4,29 +4,29 @@
 class Talosctl < Formula
   desc "CLI for out-of-band management of Kubernetes nodes created by Talos"
   homepage "https://talos.dev/"
-  version "1.10.7"
+  version "1.11.0"
   license "MPL-2.0"
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/siderolabs/talos/releases/download/v#{version}/talosctl-darwin-amd64",
       verified: "github.com/siderolabs/talos/"
-    sha256 "3ec721f593a659d37c94301944e7896551cf6f7ee016df246550611b7c5cc3cd"
+    sha256 "0cf5786d1f3ed774b3aa51bbc0e10a544e85e0b2d5f056fa4663a7b7bf9f6baf"
   elsif OS.mac? && Hardware::CPU.arm?
     url "https://github.com/siderolabs/talos/releases/download/v#{version}/talosctl-darwin-arm64",
       verified: "github.com/siderolabs/talos/"
-    sha256 "8eff248a1619a79208f00e96f2b3033b32ec8ba57c6dde191ee5416a5e81f535"
+    sha256 "81beede472bb6303b41b9119df62b81e33a67d4ff2dd7ff97da83cd950dfdfa9"
   elsif OS.linux? && Hardware::CPU.intel?
     url "https://github.com/siderolabs/talos/releases/download/v#{version}/talosctl-linux-amd64",
       verified: "github.com/siderolabs/talos/"
-    sha256 "0fe8a207b7ae925863b4af624bb1e716a28d999f32eb7aba09de4bbf60c2a9ac"
+    sha256 "255ea0da1df8c9c15fce9fa7f4ff0f0d6a18df9de100a76b24a030da51ae92a2"
   elsif OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
     url "https://github.com/siderolabs/talos/releases/download/v#{version}/talosctl-linux-armv7",
       verified: "github.com/siderolabs/talos/"
-    sha256 "bfbc575c519d81737564838a4e17fd95a1c862da3ec03868ecb3b013d04abf2f"
+    sha256 "6ef3bf976d0d997a70dc139fc78fa38b72d31a211eca901450b1248d7950d9ad"
   elsif OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
     url "https://github.com/siderolabs/talos/releases/download/v#{version}/talosctl-linux-arm64",
       verified: "github.com/siderolabs/talos/"
-    sha256 "27108265ed5797a5d59c4d4833c13de6fb200602df5b440bff6890a6a4f2f11f"
+    sha256 "a8f2799283b7a83de0f56ea2fb52a6efe593a439afa6423db62da7699dd22eeb"
   else
     odie "Unexpected platform!"
   end

--- a/update.sh
+++ b/update.sh
@@ -8,15 +8,35 @@ if [ "$#" -ne 2 ]; then
     exit 1
 fi
 
+# Use ggrep if available
+if grep_cmd=$(command -v ggrep); then
+    echo "Using GNU grep: ${grep_cmd}"
+elif grep_cmd=$(command -v grep); then
+    echo "Using system grep: ${grep_cmd}"
+else
+    echo "ERROR: grep command not found"
+    exit 2
+fi
+
+# Use gsed if available
+if sed_cmd=$(command -v gsed); then
+    echo "Using GNU sed: ${sed_cmd}"
+elif sed_cmd=$(command -v sed); then
+    echo "Using system sed: ${sed_cmd}"
+else
+    echo "ERROR: sed command not found"
+    exit 3
+fi
+
 new_ver="${2}"
 tool="${1}"
 
 formula="./Formula/${tool}.rb"
 tmp_file="/tmp/${tool}.tmp"
 
-lines="$(grep -Po '(url "\K[^"]+)|(sha256 "\K[^"]+)' "${formula}")"
+lines="$(${grep_cmd} -Po '(url "\K[^"]+)|(sha256 "\K[^"]+)' "${formula}")"
 while IFS= read -r url && read -r hash; do
-    new_url="${url/"#{version}"/"${new_ver}"}"
+    new_url="${url/"#{version}"/${new_ver}}"
     echo "===> Downloading \"${new_url}\"..."
     wget -q -O "${tmp_file}" "${new_url}"
 
@@ -25,13 +45,13 @@ while IFS= read -r url && read -r hash; do
     echo "=====> sha256: ${new_hash}"
 
     echo "=====> Updating hash in \"${formula}\"..."
-    sed -i "s/${hash}/${new_hash}/" ${formula}
+    ${sed_cmd} -i "s/${hash}/${new_hash}/" ${formula}
 
     rm ${tmp_file}
 done <<< "${lines}"
 
-current_ver="$(grep -Po 'version "\K(\d+\.\d+\.\d+)' "${formula}")"
+current_ver="$(${grep_cmd} -Po 'version "\K(\d+\.\d+\.\d+)' "${formula}")"
 echo "===> Updating version in formula \"${formula}\": ${current_ver} -> ${new_ver}"
-sed -i "s/$(echo ${current_ver} | sed 's|\.|\\.|g')/${new_ver}/" ${formula}
+${sed_cmd} -i "s/$(echo ${current_ver} | ${sed_cmd} 's|\.|\\.|g')/${new_ver}/" ${formula}
 
 echo "===> Done."


### PR DESCRIPTION
`update.sh` will now try to use GNU versions of `grep` and `sed` if available. This fixes it for MacOS (after installing `grep` and `gnu-sed` via `brew`).