### PR TITLE
DRAFT: feat: add versioned omnictl and talosctl formulas

### DIFF
--- a/Formula/omnictl@1.4.11.rb
+++ b/Formula/omnictl@1.4.11.rb
@@ -1,0 +1,51 @@
+# Copyright Sidero Labs, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+class OmnictlAT1411 < Formula
+  desc "CLI for Omni - SaaS-simple deployment of Kubernetes - on your own hardware."
+  homepage "https://omni.siderolabs.com/"
+  version "1.4.11"
+  license "BUSL-1.1"
+
+  conflicts_with "omnictl", because: "both install a binary named 'omnictl'"
+
+  if OS.mac? && Hardware::CPU.intel?
+    url "https://github.com/siderolabs/omni/releases/download/v#{version}/omnictl-darwin-amd64",
+      verified: "github.com/siderolabs/omni/"
+    sha256 "8590ea25af4090f1545961d5e1bc1c7dc1a9ddd824fa0a9e068d277295fa65b7"
+  elsif OS.mac? && Hardware::CPU.arm?
+    url "https://github.com/siderolabs/omni/releases/download/v#{version}/omnictl-darwin-arm64",
+      verified: "github.com/siderolabs/omni/"
+    sha256 "f539308603650515820c106a4a1f443cb25fbb9d23f789ac5ca676045608a503"
+  elsif OS.linux? && Hardware::CPU.intel?
+    url "https://github.com/siderolabs/omni/releases/download/v#{version}/omnictl-linux-amd64",
+      verified: "github.com/siderolabs/omni/"
+    sha256 "e57f6de2a9f71e6204471d2bfbc2f0ba4bc77f26877e33d7f017fadda319cb9b"
+  elsif OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    url "https://github.com/siderolabs/omni/releases/download/v#{version}/omnictl-linux-arm64",
+      verified: "github.com/siderolabs/omni/"
+    sha256 "c43a402e3076e85ed707a9d21207eae31cb8478a97f3d546609076a0a1330b9f"
+  else
+    odie "Unexpected platform!"
+  end
+
+  def install
+    if OS.mac? && Hardware::CPU.intel?
+      bin.install "omnictl-darwin-amd64" => "omnictl"
+    elsif OS.mac? && Hardware::CPU.arm?
+      bin.install "omnictl-darwin-arm64" => "omnictl"
+    elsif OS.linux? && Hardware::CPU.intel?
+      bin.install "omnictl-linux-amd64" => "omnictl"
+    elsif OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      bin.install "omnictl-linux-arm64" => "omnictl"
+    end
+  end
+
+  def post_install
+    generate_completions_from_executable(bin/"omnictl", "completion")
+  end
+
+  test do
+    system "#{bin}/omnictl", "--version"
+  end
+end

--- a/Formula/omnictl@1.4.rb
+++ b/Formula/omnictl@1.4.rb
@@ -1,0 +1,51 @@
+# Copyright Sidero Labs, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+class OmnictlAT14 < Formula
+  desc "CLI for Omni - SaaS-simple deployment of Kubernetes - on your own hardware."
+  homepage "https://omni.siderolabs.com/"
+  version "1.4.11"
+  license "BUSL-1.1"
+
+  conflicts_with "omnictl", because: "both install a binary named 'omnictl'"
+
+  if OS.mac? && Hardware::CPU.intel?
+    url "https://github.com/siderolabs/omni/releases/download/v#{version}/omnictl-darwin-amd64",
+      verified: "github.com/siderolabs/omni/"
+    sha256 "8590ea25af4090f1545961d5e1bc1c7dc1a9ddd824fa0a9e068d277295fa65b7"
+  elsif OS.mac? && Hardware::CPU.arm?
+    url "https://github.com/siderolabs/omni/releases/download/v#{version}/omnictl-darwin-arm64",
+      verified: "github.com/siderolabs/omni/"
+    sha256 "f539308603650515820c106a4a1f443cb25fbb9d23f789ac5ca676045608a503"
+  elsif OS.linux? && Hardware::CPU.intel?
+    url "https://github.com/siderolabs/omni/releases/download/v#{version}/omnictl-linux-amd64",
+      verified: "github.com/siderolabs/omni/"
+    sha256 "e57f6de2a9f71e6204471d2bfbc2f0ba4bc77f26877e33d7f017fadda319cb9b"
+  elsif OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    url "https://github.com/siderolabs/omni/releases/download/v#{version}/omnictl-linux-arm64",
+      verified: "github.com/siderolabs/omni/"
+    sha256 "c43a402e3076e85ed707a9d21207eae31cb8478a97f3d546609076a0a1330b9f"
+  else
+    odie "Unexpected platform!"
+  end
+
+  def install
+    if OS.mac? && Hardware::CPU.intel?
+      bin.install "omnictl-darwin-amd64" => "omnictl"
+    elsif OS.mac? && Hardware::CPU.arm?
+      bin.install "omnictl-darwin-arm64" => "omnictl"
+    elsif OS.linux? && Hardware::CPU.intel?
+      bin.install "omnictl-linux-amd64" => "omnictl"
+    elsif OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      bin.install "omnictl-linux-arm64" => "omnictl"
+    end
+  end
+
+  def post_install
+    generate_completions_from_executable(bin/"omnictl", "completion")
+  end
+
+  test do
+    system "#{bin}/omnictl", "--version"
+  end
+end

--- a/Formula/omnictl@1.rb
+++ b/Formula/omnictl@1.rb
@@ -1,0 +1,51 @@
+# Copyright Sidero Labs, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+class OmnictlAT1 < Formula
+  desc "CLI for Omni - SaaS-simple deployment of Kubernetes - on your own hardware."
+  homepage "https://omni.siderolabs.com/"
+  version "1.5.8"
+  license "BUSL-1.1"
+
+  conflicts_with "omnictl", because: "both install a binary named 'omnictl'"
+
+  if OS.mac? && Hardware::CPU.intel?
+    url "https://github.com/siderolabs/omni/releases/download/v#{version}/omnictl-darwin-amd64",
+      verified: "github.com/siderolabs/omni/"
+    sha256 "dc37a308d5d480f05c57bc65d62ea2a9c77562ae2240f24b632d448675c43328"
+  elsif OS.mac? && Hardware::CPU.arm?
+    url "https://github.com/siderolabs/omni/releases/download/v#{version}/omnictl-darwin-arm64",
+      verified: "github.com/siderolabs/omni/"
+    sha256 "269ca7928239952d9ed9a997d53c4ddb0728cbdd68325b7bec870efbd0ecf10e"
+  elsif OS.linux? && Hardware::CPU.intel?
+    url "https://github.com/siderolabs/omni/releases/download/v#{version}/omnictl-linux-amd64",
+      verified: "github.com/siderolabs/omni/"
+    sha256 "84cc2faa51d9d76fd22c606c138b20a65967a56db79b5026892a1833274da055"
+  elsif OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    url "https://github.com/siderolabs/omni/releases/download/v#{version}/omnictl-linux-arm64",
+      verified: "github.com/siderolabs/omni/"
+    sha256 "05509fd446ffd5a6b1b279b2bf61c611e2e38906f92070c4e91ba669dbd5a4bb"
+  else
+    odie "Unexpected platform!"
+  end
+
+  def install
+    if OS.mac? && Hardware::CPU.intel?
+      bin.install "omnictl-darwin-amd64" => "omnictl"
+    elsif OS.mac? && Hardware::CPU.arm?
+      bin.install "omnictl-darwin-arm64" => "omnictl"
+    elsif OS.linux? && Hardware::CPU.intel?
+      bin.install "omnictl-linux-amd64" => "omnictl"
+    elsif OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      bin.install "omnictl-linux-arm64" => "omnictl"
+    end
+  end
+
+  def post_install
+    generate_completions_from_executable(bin/"omnictl", "completion")
+  end
+
+  test do
+    system "#{bin}/omnictl", "--version"
+  end
+end

--- a/Formula/talosctl@1.12.rb
+++ b/Formula/talosctl@1.12.rb
@@ -1,0 +1,57 @@
+# Copyright Contributors to the Talos project.
+# SPDX-License-Identifier: MPL-2.0
+
+class TalosctlAT112 < Formula
+  desc "CLI for out-of-band management of Kubernetes nodes created by Talos"
+  homepage "https://talos.dev/"
+  version "1.12.4"
+  license "MPL-2.0"
+
+  conflicts_with "talosctl", because: "both install a binary named 'talosctl'"
+
+  if OS.mac? && Hardware::CPU.intel?
+    url "https://github.com/siderolabs/talos/releases/download/v#{version}/talosctl-darwin-amd64",
+      verified: "github.com/siderolabs/talos/"
+    sha256 "c0b7283352ea0ce7d6435c663727a2cfef7f504c9b404f982b2f960501f3d9c8"
+  elsif OS.mac? && Hardware::CPU.arm?
+    url "https://github.com/siderolabs/talos/releases/download/v#{version}/talosctl-darwin-arm64",
+      verified: "github.com/siderolabs/talos/"
+    sha256 "f4c94d4832e9d41f67cc63cd362cc0bfd44d8c675e9ff04541411be40916096c"
+  elsif OS.linux? && Hardware::CPU.intel?
+    url "https://github.com/siderolabs/talos/releases/download/v#{version}/talosctl-linux-amd64",
+      verified: "github.com/siderolabs/talos/"
+    sha256 "6b85f633721e02d31c8a28a633c9cd8ebfb7e41677ff29e94236a082d4cd6cd9"
+  elsif OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
+    url "https://github.com/siderolabs/talos/releases/download/v#{version}/talosctl-linux-armv7",
+      verified: "github.com/siderolabs/talos/"
+    sha256 "1a78c6752ec3613062de93aa989ac7603eeb866ec7a76e2e43cc8bfe4ce7e554"
+  elsif OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    url "https://github.com/siderolabs/talos/releases/download/v#{version}/talosctl-linux-arm64",
+      verified: "github.com/siderolabs/talos/"
+    sha256 "5d6f37684d337a9b689216a4e7cc07b58996bad34afbd9d032ab1bd058cfe282"
+  else
+    odie "Unexpected platform!"
+  end
+
+  def install
+    if OS.mac? && Hardware::CPU.intel?
+      bin.install "talosctl-darwin-amd64" => "talosctl"
+    elsif OS.mac? && Hardware::CPU.arm?
+      bin.install "talosctl-darwin-arm64" => "talosctl"
+    elsif OS.linux? && Hardware::CPU.intel?
+      bin.install "talosctl-linux-amd64" => "talosctl"
+    elsif OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
+      bin.install "talosctl-linux-armv7" => "talosctl"
+    elsif OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      bin.install "talosctl-linux-arm64" => "talosctl"
+    end
+  end
+
+  def post_install
+    generate_completions_from_executable(bin/"talosctl", "completion")
+  end
+
+  test do
+    system "#{bin}/talosctl", "version"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ brew tap siderolabs/tap
 brew install talosctl omnictl
 ```
 
+## Install specific major/minor versions
+
+Versioned formulae are also available for pinned release lines:
+
+```bash
+brew tap siderolabs/tap
+brew install siderolabs/tap/omnictl@1
+brew install siderolabs/tap/omnictl@1.4
+brew install siderolabs/tap/omnictl@1.4.11
+brew install siderolabs/tap/talosctl@1.12
+```
+
+If the unversioned formula is already installed, unlink it first (or uninstall it), as both install the same binary names:
+
+```bash
+brew unlink omnictl talosctl
+brew install siderolabs/tap/omnictl@1.4 siderolabs/tap/talosctl@1.12
+```
+
 ## Updates
 
 Currently, updates of this repository are manual


### PR DESCRIPTION
Just an idea, my Omni is running on 1.4.x but brew install the latest 1.5

For each command I got a: 
```[WARN] omnictl version differs from the backend version: "1.5.0" vs "1.4.11".```

Could you consider supporting a
```brew install omnictl@1.4```

same for Talosctl