### PR TITLE
chore: bump talosctl to v1.13.0

### DIFF
--- a/Formula/omnictl.rb
+++ b/Formula/omnictl.rb
@@ -37,10 +37,10 @@ class Omnictl < Formula
     elsif OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       bin.install "omnictl-linux-arm64" => "omnictl"
     end
-  end
 
-  def post_install
-    generate_completions_from_executable(bin/"omnictl", "completion")
+    chmod 0555, bin/"omnictl"
+
+    generate_completions_from_executable(bin/"omnictl", shell_parameter_format: :cobra)
   end
 
   test do

--- a/Formula/talosctl.rb
+++ b/Formula/talosctl.rb
@@ -4,29 +4,29 @@
 class Talosctl < Formula
   desc "CLI for out-of-band management of Kubernetes nodes created by Talos"
   homepage "https://talos.dev/"
-  version "1.12.5"
+  version "1.13.0"
   license "MPL-2.0"
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/siderolabs/talos/releases/download/v#{version}/talosctl-darwin-amd64",
       verified: "github.com/siderolabs/talos/"
-    sha256 "8a58a951144d7f1a8eec4b6bb725553e4cf0d9c5b66785a8e0247890ec144f10"
+    sha256 "166c4cb74765837e20430516be739757376df769346fd70ff1093a88391dcfa8"
   elsif OS.mac? && Hardware::CPU.arm?
     url "https://github.com/siderolabs/talos/releases/download/v#{version}/talosctl-darwin-arm64",
       verified: "github.com/siderolabs/talos/"
-    sha256 "8e4adec89acea650008f65b5e53c601a5115b3b5d6b6d15a8c215e533451b8a6"
+    sha256 "728cb09e34eadcb2c122c626daba8202281944f4851b43e9e37836551c8e9d19"
   elsif OS.linux? && Hardware::CPU.intel?
     url "https://github.com/siderolabs/talos/releases/download/v#{version}/talosctl-linux-amd64",
       verified: "github.com/siderolabs/talos/"
-    sha256 "3fbd456ec98f96dca42de0528220898177077bf023e3ae9432fb90a2dbe8cf66"
+    sha256 "4aa5cd191c708b8c1a3b358bfd7dd21fb0cc6bd4dc7a07f2aa925cd2a8473bae"
   elsif OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
     url "https://github.com/siderolabs/talos/releases/download/v#{version}/talosctl-linux-armv7",
       verified: "github.com/siderolabs/talos/"
-    sha256 "e454e853794abddb8c4f98ef2fa7daffdedba292b64062dc2b66e12e8ab3daf8"
+    sha256 "5aa46ac074929588371c1303a29bced206fadeab36ff7f3f03fc4426764a3a49"
   elsif OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
     url "https://github.com/siderolabs/talos/releases/download/v#{version}/talosctl-linux-arm64",
       verified: "github.com/siderolabs/talos/"
-    sha256 "108b1745ddb98838b15537e6f7951d25cfaafbda62c5740d38273ddb1aea0fb1"
+    sha256 "6171ece2062a350d2fc12aa14894a4ad06235005c12f76701e0127ffdf6026b9"
   else
     odie "Unexpected platform!"
   end
@@ -43,10 +43,10 @@ class Talosctl < Formula
     elsif OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       bin.install "talosctl-linux-arm64" => "talosctl"
     end
-  end
 
-  def post_install
-    generate_completions_from_executable(bin/"talosctl", "completion")
+    chmod 0555, bin/"talosctl"
+
+    generate_completions_from_executable(bin/"talosctl", shell_parameter_format: :cobra)
   end
 
   test do


### PR DESCRIPTION
This brings in the Talosctl v1.13.0 release.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
