### PR TITLE
fix(talosctl): use 'completion' subcommand for shell completions

### DIFF
--- a/Formula/talosctl.rb
+++ b/Formula/talosctl.rb
@@ -46,7 +46,7 @@ class Talosctl < Formula
 
     chmod 0555, bin/"talosctl"
 
-    generate_completions_from_executable(bin/"talosctl", shell_parameter_format: :cobra)
+    generate_completions_from_executable(bin/"talosctl", "completion")
   end
 
   test do


### PR DESCRIPTION
## Problem

`brew install talosctl` and `brew upgrade talosctl` are broken on talosctl 1.13.0:

```
==> Upgrading siderolabs/tap/talosctl
  1.12.5 -> 1.13.0
unknown command "cobrabash" for "talosctl"
...
Error: Failure while executing; `{"SHELL"=>"bash"} /opt/homebrew/Cellar/talosctl/1.13.0/bin/talosctl cobrabash` exited with 1.
```

## Root cause

talosctl 1.13.0 dropped the legacy `cobrabash` / `cobrazsh` / `cobrafish` / `cobrapwsh` helper subcommands in favor of the standard cobra `completion <shell>` form.

The current formula uses `shell_parameter_format: :cobra`, but **`:cobra` is not a defined symbol** in Homebrew's `shell_parameter_format` mapping. Looking at [`Library/Homebrew/formula.rb#generate_completions_from_executable`](https://github.com/Homebrew/brew/blob/main/Library/Homebrew/formula.rb), only `:flag`, `:arg`, `:none`, `:click`, `:clap` and string prefixes are handled — anything else falls through to:

```ruby
else
  "#{shell_parameter_format}#{shell_argument}"
end
```

…which concatenates `"cobra"` + `"bash"` → `"cobrabash"`, etc. Hence the broken invocation.

## Fix

Pass `"completion"` as a subcommand argument and let Homebrew append the shell name as a positional arg (the default behavior when `shell_parameter_format` is `nil`). This produces the correct cobra-standard calls:

- `talosctl completion bash`
- `talosctl completion zsh`
- `talosctl completion fish`

```diff
-    generate_completions_from_executable(bin/"talosctl", shell_parameter_format: :cobra)
+    generate_completions_from_executable(bin/"talosctl", "completion")
```

This is the same idiom used by other cobra-based CLIs in homebrew-core (kubectl, helm, …).

## Test

Verified locally on macOS 26 / arm64 against the talosctl 1.13.0 bottle:

```
$ brew reinstall --formula ./Formula/talosctl.rb
==> Reinstalling talosctl
🍺  /opt/homebrew/Cellar/talosctl/1.13.0: 7 files, 91.7MB
==> Caveats
zsh completions have been installed to:
  /opt/homebrew/share/zsh/site-functions

$ talosctl version --client --short
Client:
Talos v1.13.0

$ head -1 /opt/homebrew/etc/bash_completion.d/talosctl
# bash completion V2 for talosctl                             -*- shell-script -*-

$ head -1 /opt/homebrew/share/zsh/site-functions/_talosctl
#compdef talosctl
```

Both bash and zsh completion files were generated correctly and load without errors.