### PR TITLE
update.sh compatibility with macos and linux

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -8,16 +8,6 @@ if [ "$#" -ne 2 ]; then
     exit 1
 fi
 
-# Use ggrep if available
-if grep_cmd=$(command -v ggrep); then
-    echo "Using GNU grep: ${grep_cmd}"
-elif grep_cmd=$(command -v grep); then
-    echo "Using system grep: ${grep_cmd}"
-else
-    echo "ERROR: grep command not found"
-    exit 2
-fi
-
 # Use gsed if available
 if sed_cmd=$(command -v gsed); then
     echo "Using GNU sed: ${sed_cmd}"
@@ -34,7 +24,7 @@ tool="${1}"
 formula="./Formula/${tool}.rb"
 tmp_file="/tmp/${tool}.tmp"
 
-lines="$(${grep_cmd} -Po '(url "\K[^"]+)|(sha256 "\K[^"]+)' "${formula}")"
+lines="$(${sed_cmd} -nE 's/.*(url|sha256) "([^"]+)".*/\2/p' "${formula}")"
 while IFS= read -r url && read -r hash; do
     new_url="${url/"#{version}"/${new_ver}}"
     echo "===> Downloading \"${new_url}\"..."
@@ -45,13 +35,13 @@ while IFS= read -r url && read -r hash; do
     echo "=====> sha256: ${new_hash}"
 
     echo "=====> Updating hash in \"${formula}\"..."
-    ${sed_cmd} -i "s/${hash}/${new_hash}/" ${formula}
+    ${sed_cmd} "s/${hash}/${new_hash}/" "${formula}" > "${formula}.tmp" && mv "${formula}.tmp" "${formula}"
 
     rm ${tmp_file}
 done <<< "${lines}"
 
-current_ver="$(${grep_cmd} -Po 'version "\K(\d+\.\d+\.\d+)' "${formula}")"
+current_ver="$(${sed_cmd} -nE 's/.*version "([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' "${formula}")"
 echo "===> Updating version in formula \"${formula}\": ${current_ver} -> ${new_ver}"
-${sed_cmd} -i "s/$(echo ${current_ver} | ${sed_cmd} 's|\.|\\.|g')/${new_ver}/" ${formula}
+${sed_cmd} "s/$(echo ${current_ver} | ${sed_cmd} 's|\.|\\.|g')/${new_ver}/" "${formula}" > "${formula}.tmp" && mv "${formula}.tmp" "${formula}"
 
 echo "===> Done."


### PR DESCRIPTION
The `update.sh` script expects gnu versions of `grep` and `sed` and would fail when running on a MacOS without the gnu tools. This change makes the `update.sh` script compatible with both Linux and MacOS without gnu tools:

- replaces grep commands with sed (grep is no longer needed)
- update sed commands so they work on both platforms

Tested on MacOS 26.5.1:

    $ ./update.sh talosctl 1.13.5
    ...
    ===> Updating version in formula "./Formula/talosctl.rb": 1.13.3 -> 1.13.5
    ===> Done.
    $ sha256sum Formula/talosctl.rb
    c08893487c71ab071baf171f8ee046a84ce1c6df773719897e8118a806256ee4  Formula/talosctl.rb

Tested on Ubuntu 24.04:

    $ ./update.sh talosctl 1.13.5
    ...
    ===> Updating version in formula "./Formula/talosctl.rb": 1.13.3 -> 1.13.5
    ===> Done.
    $ sha256sum Formula/talosctl.rb
    c08893487c71ab071baf171f8ee046a84ce1c6df773719897e8118a806256ee4  Formula/talosctl.rb

Both produce the same result in `Formula/talosctl.rb`:

```
$ git diff Formula/talosctl.rb
diff --git a/Formula/talosctl.rb b/Formula/talosctl.rb
index e940e06..827b481 100644
--- a/Formula/talosctl.rb
+++ b/Formula/talosctl.rb
@@ -4,29 +4,29 @@
 class Talosctl < Formula
   desc "CLI for out-of-band management of Kubernetes nodes created by Talos"
   homepage "https://talos.dev/"
-  version "1.13.3"
+  version "1.13.5"
   license "MPL-2.0"

   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/siderolabs/talos/releases/download/v#{version}/talosctl-darwin-amd64",
       verified: "github.com/siderolabs/talos/"
-    sha256 "e283191829456c5e24c2619f54f1e28864b8140b142979c2c42d7564c1aaf4da"
+    sha256 "b5808a8f650c53987d0133704259f3cdf31c081710bda598f9b4cab934abc78c"
   elsif OS.mac? && Hardware::CPU.arm?
     url "https://github.com/siderolabs/talos/releases/download/v#{version}/talosctl-darwin-arm64",
       verified: "github.com/siderolabs/talos/"
-    sha256 "badbf454e3fea46018af69b8704b7acdccb7a70906538619da6bdabc382c8f05"
+    sha256 "5cfc42f5a51b01ea391c9760a1c5450517f7e85a74d145fd20b6abc4ac1df37e"
   elsif OS.linux? && Hardware::CPU.intel?
     url "https://github.com/siderolabs/talos/releases/download/v#{version}/talosctl-linux-amd64",
       verified: "github.com/siderolabs/talos/"
-    sha256 "50e87176dc532fd82b3136f321e8c292e175c98a4c6573c505b07fef21e476cf"
+    sha256 "cb12209727c0c4d57d74c0595f34d441ba491421e1d3c8a5142ed91028a20232"
   elsif OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
     url "https://github.com/siderolabs/talos/releases/download/v#{version}/talosctl-linux-armv7",
       verified: "github.com/siderolabs/talos/"
-    sha256 "f17bbda66535e36bdc10322e2cd0527d7f7db5310ff3be96a97b5a5e14525d2a"
+    sha256 "fb531c5503e0626edbd8782ef64718a5f9ac0ff44d91fea601ca83b1d77cb731"
   elsif OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
     url "https://github.com/siderolabs/talos/releases/download/v#{version}/talosctl-linux-arm64",
       verified: "github.com/siderolabs/talos/"
-    sha256 "549bcdf2bce9552bc6aee69bd6fb5b0618efb048831cdf729b3dbf92b59f3ae0"
+    sha256 "bd053d8264c1b0c091cbaf15e7b414ab1cd14a56ddd5860f2e2ba01e5aee3bc3"
   else
     odie "Unexpected platform!"
   end
```